### PR TITLE
Removing env(), typo & tests updated

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,0 +1,32 @@
+name: Laravel
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  laravel-tests:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Copy .env
+      run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+    - name: Install Dependencies
+      run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+    - name: Generate key
+      run: php artisan key:generate
+    - name: Directory Permissions
+      run: chmod -R 777 storage bootstrap/cache
+    - name: Create Database
+      run: |
+        mkdir -p database
+        touch database/database.sqlite
+    - name: Execute tests (Unit and Feature tests) via PHPUnit
+      env:
+        DB_CONNECTION: sqlite
+        DB_DATABASE: database/database.sqlite
+      run: vendor/bin/phpunit

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -17,10 +17,6 @@ jobs:
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
     - name: Install Dependencies
       run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-    - name: Generate key
-      run: php artisan key:generate
-    - name: Directory Permissions
-      run: chmod -R 777 storage bootstrap/cache
     - name: Create Database
       run: |
         mkdir -p database

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Homestead.json
 
 # Rocketeer PHP task runner and deployment package. https://github.com/rocketeers/rocketeer
 .rocketeer/
+.phpunit.result.cache

--- a/src/Models/Traits/HasEncryptedAttributes.php
+++ b/src/Models/Traits/HasEncryptedAttributes.php
@@ -115,16 +115,13 @@ trait HasEncryptedAttributes
 
             if (is_null($originalValue)) {
                 $this->{$this->encrypted[$key]['hasBlindIndex']} = null;
-
-            } else if ('' === $originalValue) {
+            } else if ('' === $originalValue) { // TODO: add config('ENCRYPT_EMPTY_STRING_BI')
                 $this->{$this->encrypted[$key]['hasBlindIndex']} = '';
-
             } else {
                 $this->{$this->encrypted[$key]['hasBlindIndex']} = $this->getHash($originalValue);
             }
         }
     }
-
 
     /**
      * @param $key
@@ -147,7 +144,6 @@ trait HasEncryptedAttributes
         return $value;
     }
 
-
     /**
      * @param $value
      * @param $type
@@ -163,7 +159,6 @@ trait HasEncryptedAttributes
         return (string)$value;
     }
 
-
     /**
      * @param $value
      * @param null $format
@@ -178,16 +173,14 @@ trait HasEncryptedAttributes
         }
     }
 
-
     /**
      * @param $originalValue
      * @return string
      */
     private function getHash($originalValue)
     {
-        return hash_hmac($this->hashAlg, (string)$originalValue, env('APP_KEY'));
+        return hash_hmac($this->hashAlg, (string)$originalValue, config('app.key'));
     }
-
 
     /**
      * @param $key
@@ -242,7 +235,6 @@ trait HasEncryptedAttributes
         return true;
     }
 
-
     /**
      * @param $query
      * @param array $blindIndexQuery
@@ -265,7 +257,6 @@ trait HasEncryptedAttributes
 
         throw new \Exception("Blind index column for " . key($blindIndexQuery) . " not found");
     }
-
 
     /**
      * @param $query

--- a/src/Models/Traits/HasEncryptedAttributes.php
+++ b/src/Models/Traits/HasEncryptedAttributes.php
@@ -56,7 +56,6 @@ trait HasEncryptedAttributes
      */
     public $hashAlg = 'sha256';
 
-
     /**
      * @var array
      */
@@ -68,8 +67,8 @@ trait HasEncryptedAttributes
      * @param $value
      * @return string
      */
-    private function setEncryptedHashedBIAttributes($key, $value){
-
+    private function setEncryptedHashedBIAttributes($key, $value)
+    {
         if (array_key_exists($key, $this->encrypted)) {
 
             $this->checkTypes($key, $value);
@@ -80,33 +79,31 @@ trait HasEncryptedAttributes
         return $this->setHashed($key, $value);
     }
 
-
     /**
      * @param $value
      * @return string
      */
-    private function setEncrypted($value){
+    private function setEncrypted($value)
+    {
         if (!is_null($value)) {
             $value = encrypt((string)$value);
         }
         return $value;
     }
 
-
     /**
      * @param $key
      * @param $value
      * @return string
      */
-    private function setHashed($key, $value){
-
+    private function setHashed($key, $value)
+    {
         if (in_array($key, $this->hashed??[]) && !is_null($value) && '' != $value) {
             $value = $this->getHash($value);
         }
 
         return $value;
     }
-
 
     /**
      * @param $key
@@ -120,7 +117,7 @@ trait HasEncryptedAttributes
                 $this->{$this->encrypted[$key]['hasBlindIndex']} = null;
 
             } else if ('' === $originalValue) {
-                    $this->{$this->encrypted[$key]['hasBlindIndex']} = '';
+                $this->{$this->encrypted[$key]['hasBlindIndex']} = '';
 
             } else {
                 $this->{$this->encrypted[$key]['hasBlindIndex']} = $this->getHash($originalValue);
@@ -137,7 +134,6 @@ trait HasEncryptedAttributes
     private function getDecryptIfEncrypted($key, $value)
     {
         if (array_key_exists($key, $this->encrypted) && !empty($value)) {
-
             $decryptionType = array_key_exists('type', $this->encrypted[$key]) ? $this->encrypted[$key]['type'] : 'string';
 
             if ($decryptionType == 'date') {
@@ -206,7 +202,7 @@ trait HasEncryptedAttributes
             $type = array_key_exists('type', $this->encrypted[$key]) ? $this->encrypted[$key]['type'] : 'string';
             $format = array_key_exists('dateFormat', $this->encrypted[$key]) ? $this->encrypted[$key]['dateFormat'] : null;
 
-            switch($type) {
+            switch ($type) {
                 case 'date':
                     $this->castDate($value, $format);
                     break;
@@ -217,7 +213,6 @@ trait HasEncryptedAttributes
                     if(!in_array($type, $this->primitiveTypes)) throw new TypeError("Encryption error, $type not a supported type of 'integer', 'boolean', 'float', 'string', 'date'");
                     $this->checkType($key, $value, [$type]);
             }
-
         }
 
         return true;
@@ -229,18 +224,18 @@ trait HasEncryptedAttributes
      * @param array $types
      * @return bool
      */
-    private function checkType($key, $value, array $types){
-
+    private function checkType($key, $value, array $types)
+    {
         $hasMatchedType = false;
 
-        foreach($types as $type){
-            if (gettype($value) == $type){
+        foreach ($types as $type) {
+            if (gettype($value) == $type) {
                 $hasMatchedType = true;
                 break;
             }
         }
 
-        if (!$hasMatchedType){
+        if (!$hasMatchedType) {
             throw new TypeError("Encryption error, $key not of correct type or null. Type is: " . gettype($value));
         }
 
@@ -281,7 +276,6 @@ trait HasEncryptedAttributes
     public function scopeOrWhereBI($query, array $blindIndexQuery)
     {
         if (array_key_exists(key($blindIndexQuery), $this->encrypted) && array_key_exists('hasBlindIndex', $this->encrypted[key($blindIndexQuery)])) {
-
             $columnToSearch = $this->encrypted[key($blindIndexQuery)]['hasBlindIndex'];
             $unHashedValueToSearch = $blindIndexQuery[key($blindIndexQuery)];
 
@@ -295,21 +289,18 @@ trait HasEncryptedAttributes
         throw new \Exception("Blind index column for " . key($blindIndexQuery) . " not found");
     }
 
-
     //
     //Eloquent Model method overrides below
     //
-
 
     /**
      * @param $key
      * @return mixed
      */
-    protected function getAttributeFromArray($key){
+    protected function getAttributeFromArray($key)
+    {
         return $this->getDecryptIfEncrypted($key, parent::getAttributeFromArray($key));
     }
-
-
 
     /**
      * @return array
@@ -325,27 +316,24 @@ trait HasEncryptedAttributes
         return $array;
     }
 
-
-
     /**
      * @param $key
      * @param $value
      */
     public function setAttribute($key, $value)
     {
-        if($value !== $this->$key){
+        if ($value !== $this->$key) {
             parent::setAttribute($key, $this->setEncryptedHashedBIAttributes($key, $value));
         }
     }
 
-
     /**
-     * List all encripted columns so we can do some magic after
+     * List all encrypted columns so we can do some magic after
      * @return array
      */
-    public function encriptedColumns()
+    public function encryptedColumns()
     {
-      return (!empty($this->encrypted))? $this->encrypted : [];
+        return (!empty($this->encrypted))? $this->encrypted : [];
     }
 
 }

--- a/tests/Unit/Traits/Models/HasEncryptedAttributesTest.php
+++ b/tests/Unit/Traits/Models/HasEncryptedAttributesTest.php
@@ -11,9 +11,9 @@ use Carbon\Carbon;
 class HasEncryptedAttributesTest extends TestCase
 {
     /**
-     *
+     * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -45,19 +45,19 @@ class HasEncryptedAttributesTest extends TestCase
 
         foreach ($models as $model) {
 
-            $this->assertInternalType('string', $model->name);
-            $this->assertInternalType('string', $model->encrypt_string);
-            $this->assertInternalType('integer', $model->encrypt_integer);
-            $this->assertInternalType('boolean', $model->encrypt_boolean);
-            $this->assertInternalType('boolean', $model->encrypt_another_boolean);
-            $this->assertInternalType('float', $model->encrypt_float);
+            $this->assertIsString($model->name);
+            $this->assertIsString($model->encrypt_string);
+            $this->assertIsInt($model->encrypt_integer);
+            $this->assertIsBool($model->encrypt_boolean);
+            $this->assertIsBool($model->encrypt_another_boolean);
+            $this->assertIsFloat($model->encrypt_float);
             $this->assertInstanceOf(Carbon::class, $model->encrypt_date);
-            $this->assertInternalType('string', $model->encrypt_string_bi);
-            $this->assertInternalType('string', $model->encrypt_integer_bi);
-            $this->assertInternalType('string', $model->encrypt_boolean_bi);
-            $this->assertInternalType('string', $model->encrypt_float_bi);
-            $this->assertInternalType('string', $model->encrypt_date_bi);
-            $this->assertInternalType('string', $model->hash_string);
+            $this->assertIsString($model->encrypt_string_bi);
+            $this->assertIsString($model->encrypt_integer_bi);
+            $this->assertIsString($model->encrypt_boolean_bi);
+            $this->assertIsString($model->encrypt_float_bi);
+            $this->assertIsString($model->encrypt_date_bi);
+            $this->assertIsString($model->hash_string);
         }
 
     }
@@ -98,18 +98,18 @@ class HasEncryptedAttributesTest extends TestCase
 
         foreach ($models as $model) {
             $this->assertEquals('', $model->encrypt_string);
-            $this->assertInternalType('string', $model->encrypt_string);
+            $this->assertIsString($model->encrypt_string);
             $this->assertTrue(is_null($model->encrypt_integer));
             $this->assertTrue(is_null($model->encrypt_boolean));
             $this->assertTrue(is_null($model->encrypt_another_boolean));
             $this->assertTrue(is_null($model->encrypt_date));
-            $this->assertInternalType('string', $model->encrypt_string_bi);
+            $this->assertIsString($model->encrypt_string_bi);
             $this->assertTrue(is_null($model->encrypt_integer_bi));
             $this->assertTrue(is_null($model->encrypt_boolean_bi));
             $this->assertTrue(is_null($model->encrypt_float_bi));
             $this->assertTrue(is_null($model->encrypt_date_bi));
             $this->assertEquals('', $model->hash_string);
-            $this->assertInternalType('string', $model->hash_string);
+            $this->assertIsString($model->hash_string);
             $this->assertTrue(is_null($model->encrypt_float));
         }
     }
@@ -128,19 +128,19 @@ class HasEncryptedAttributesTest extends TestCase
 
             $array = $model->toArray();
 
-            $this->assertInternalType('string', $array['name']);
-            $this->assertInternalType('string', $array['encrypt_string']);
-            $this->assertInternalType('integer', $array['encrypt_integer']);
-            $this->assertInternalType('boolean', $array['encrypt_boolean']);
-            $this->assertInternalType('boolean', $array['encrypt_another_boolean']);
-            $this->assertInternalType('float', $array['encrypt_float']);
+            $this->assertIsString($array['name']);
+            $this->assertIsString($array['encrypt_string']);
+            $this->assertIsInt($array['encrypt_integer']);
+            $this->assertIsBool($array['encrypt_boolean']);
+            $this->assertIsBool($array['encrypt_another_boolean']);
+            $this->assertIsFloat($array['encrypt_float']);
             $this->assertInstanceOf(Carbon::class, $array['encrypt_date']);
-            $this->assertInternalType('string', $array['encrypt_string_bi']);
-            $this->assertInternalType('string', $array['encrypt_integer_bi']);
-            $this->assertInternalType('string', $array['encrypt_boolean_bi']);
-            $this->assertInternalType('string', $array['encrypt_float_bi']);
-            $this->assertInternalType('string', $array['encrypt_date_bi']);
-            $this->assertInternalType('string', $array['hash_string']);
+            $this->assertIsString($array['encrypt_string_bi']);
+            $this->assertIsString($array['encrypt_integer_bi']);
+            $this->assertIsString($array['encrypt_boolean_bi']);
+            $this->assertIsString($array['encrypt_float_bi']);
+            $this->assertIsString($array['encrypt_date_bi']);
+            $this->assertIsString($array['hash_string']);
         }
 
     }
@@ -187,18 +187,18 @@ class HasEncryptedAttributesTest extends TestCase
             $array = $model->toArray();
 
             $this->assertEquals('', $array['encrypt_string']);
-            $this->assertInternalType('string', $array['encrypt_string']);
+            $this->assertIsString($array['encrypt_string']);
             $this->assertTrue(is_null($array['encrypt_integer']));
             $this->assertTrue(is_null($array['encrypt_boolean']));
             $this->assertTrue(is_null($array['encrypt_another_boolean']));
             $this->assertTrue(is_null($array['encrypt_date']));
-            $this->assertInternalType('string', $array['encrypt_string_bi']);
+            $this->assertIsString($array['encrypt_string_bi']);
             $this->assertTrue(is_null($array['encrypt_integer_bi']));
             $this->assertTrue(is_null($array['encrypt_boolean_bi']));
             $this->assertTrue(is_null($array['encrypt_float_bi']));
             $this->assertTrue(is_null($array['encrypt_date_bi']));
             $this->assertEquals('', $array['hash_string']);
-            $this->assertInternalType('string', $array['hash_string']);
+            $this->assertIsString($array['hash_string']);
             $this->assertTrue(is_null($array['encrypt_float']));
         }
     }
@@ -331,13 +331,13 @@ class HasEncryptedAttributesTest extends TestCase
             hash_hmac('sha256', 'Another unqiue string that has not been generated',
                 env('APP_KEY')));
 
-        $this->assertInternalType('string', $model->encrypt_string);
-        $this->assertInternalType('integer', $model->encrypt_integer);
-        $this->assertInternalType('boolean', $model->encrypt_boolean);
-        $this->assertInternalType('boolean', $model->encrypt_another_boolean);
-        $this->assertInternalType('float', $model->encrypt_float);
+        $this->assertIsString($model->encrypt_string);
+        $this->assertIsInt($model->encrypt_integer);
+        $this->assertIsBool($model->encrypt_boolean);
+        $this->assertIsBool($model->encrypt_another_boolean);
+        $this->assertIsFloat($model->encrypt_float);
         $this->assertInstanceOf(Carbon::class, $model->encrypt_date);
-        $this->assertInternalType('string', $model->hash_string);
+        $this->assertIsString($model->hash_string);
 
         $this->assertEquals($model->encrypt_string_bi, hash_hmac('sha256', (string)'newValue',
             env('APP_KEY')));
@@ -429,17 +429,17 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals($model->encrypt_date, null);
         $this->assertEquals($model->hash_string, '');
 
-        $this->assertInternalType('string', $model->encrypt_string);
-        $this->assertInternalType('integer', $model->encrypt_integer);
-        $this->assertInternalType('boolean', $model->encrypt_boolean);
-        $this->assertInternalType('boolean', $model->encrypt_another_boolean);
-        $this->assertInternalType('float', $model->encrypt_float);
+        $this->assertIsString($model->encrypt_string);
+        $this->assertIsInt($model->encrypt_integer);
+        $this->assertIsBool($model->encrypt_boolean);
+        $this->assertIsBool($model->encrypt_another_boolean);
+        $this->assertIsFloat($model->encrypt_float);
         $this->assertTrue(is_null($model->encrypt_date));
-        $this->assertInternalType('null', $model->encrypt_date);
-        $this->assertInternalType('string', $model->hash_string);
+        $this->assertNull($model->encrypt_date);
+        $this->assertIsString($model->hash_string);
 
         $this->assertEquals($model->encrypt_string_bi, '');
-        $this->assertInternalType('string', $model->encrypt_string_bi);
+        $this->assertIsString($model->encrypt_string_bi);
         $this->assertEquals($model->encrypt_integer_bi, hash_hmac('sha256', (string)0,
             env('APP_KEY')));
         $this->assertEquals($model->encrypt_boolean_bi, hash_hmac('sha256', (string)false,
@@ -487,13 +487,13 @@ class HasEncryptedAttributesTest extends TestCase
             hash_hmac('sha256', 'Another unqiue string that has not been generated',
                 env('APP_KEY')));
 
-        $this->assertInternalType('string', $model->encrypt_string);
-        $this->assertInternalType('integer', $model->encrypt_integer);
-        $this->assertInternalType('boolean', $model->encrypt_boolean);
-        $this->assertInternalType('boolean', $model->encrypt_another_boolean);
-        $this->assertInternalType('float', $model->encrypt_float);
+        $this->assertIsString($model->encrypt_string);
+        $this->assertIsInt($model->encrypt_integer);
+        $this->assertIsBool($model->encrypt_boolean);
+        $this->assertIsBool($model->encrypt_another_boolean);
+        $this->assertIsFloat($model->encrypt_float);
         $this->assertInstanceOf(Carbon::class, $model->encrypt_date);
-        $this->assertInternalType('string', $model->hash_string);
+        $this->assertIsString($model->hash_string);
 
         $this->assertEquals($model->encrypt_string_bi, hash_hmac('sha256', (string)'newValue',
             env('APP_KEY')));
@@ -585,17 +585,17 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals($model->encrypt_date, null);
         $this->assertEquals($model->hash_string, '');
 
-        $this->assertInternalType('string', $model->encrypt_string);
-        $this->assertInternalType('integer', $model->encrypt_integer);
-        $this->assertInternalType('boolean', $model->encrypt_boolean);
-        $this->assertInternalType('boolean', $model->encrypt_another_boolean);
-        $this->assertInternalType('float', $model->encrypt_float);
+        $this->assertIsString($model->encrypt_string);
+        $this->assertIsInt($model->encrypt_integer);
+        $this->assertIsBool($model->encrypt_boolean);
+        $this->assertIsBool($model->encrypt_another_boolean);
+        $this->assertIsFloat($model->encrypt_float);
         $this->assertTrue(is_null($model->encrypt_date));
-        $this->assertInternalType('null', $model->encrypt_date);
-        $this->assertInternalType('string', $model->hash_string);
+        $this->assertNull($model->encrypt_date);
+        $this->assertIsString($model->hash_string);
 
         $this->assertEquals($model->encrypt_string_bi, '');
-        $this->assertInternalType('string', $model->encrypt_string_bi);
+        $this->assertIsString($model->encrypt_string_bi);
         $this->assertEquals($model->encrypt_integer_bi, hash_hmac('sha256', (string)0,
             env('APP_KEY')));
         $this->assertEquals($model->encrypt_boolean_bi, hash_hmac('sha256', (string)false,
@@ -1081,6 +1081,20 @@ class HasEncryptedAttributesTest extends TestCase
         $models = TestModel::where(1,2)->orWhereBI(['encrypt_float' => 20.0001])->Get();
 
         $this->assertEquals(0, count($models));
+    }
+
+    public function envConfigTest()
+    {
+
+        echo "\n";
+        echo "\n";
+        echo config("app.key");
+        echo "\n";
+        echo env("APP_KEY");
+        echo "\n";
+        echo "\n";
+
+        $this->assertEquals(true, true);
     }
 
 }

--- a/tests/Unit/Traits/Models/HasEncryptedAttributesTest.php
+++ b/tests/Unit/Traits/Models/HasEncryptedAttributesTest.php
@@ -221,7 +221,7 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals(($models->get(0))->encrypt_date, '2043-12-23 23:59:59');
         $this->assertEquals(($models->get(0))->hash_string,
             hash_hmac('sha256', 'A unqiue string that has not been generated',
-                env('APP_KEY')));
+                config('app.key')));
 
     }
 
@@ -243,7 +243,7 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals(($models->get(0))->encrypt_date, '2043-12-23 23:59:59');
         $this->assertEquals(($models->get(0))->hash_string,
             hash_hmac('sha256', 'A unqiue string that has not been generated',
-                env('APP_KEY')));
+                config('app.key')));
 
     }
 
@@ -266,7 +266,7 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals($array['encrypt_float'], 10.0001);
         $this->assertEquals($array['encrypt_date'], '2043-12-23 23:59:59');
         $this->assertEquals($array['hash_string'], hash_hmac('sha256', 'A unqiue string that has not been generated',
-            env('APP_KEY')));
+            config('app.key')));
 
     }
 
@@ -289,7 +289,7 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals($array['encrypt_float'], 10.0001);
         $this->assertEquals($array['encrypt_date'], '2043-12-23 23:59:59');
         $this->assertEquals($array['hash_string'], hash_hmac('sha256', 'A unqiue string that has not been generated',
-            env('APP_KEY')));
+            config('app.key')));
 
     }
 
@@ -329,7 +329,7 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals($model->encrypt_date, '2012-12-13 13:39:29');
         $this->assertEquals($model->hash_string,
             hash_hmac('sha256', 'Another unqiue string that has not been generated',
-                env('APP_KEY')));
+                config('app.key')));
 
         $this->assertIsString($model->encrypt_string);
         $this->assertIsInt($model->encrypt_integer);
@@ -340,15 +340,15 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertIsString($model->hash_string);
 
         $this->assertEquals($model->encrypt_string_bi, hash_hmac('sha256', (string)'newValue',
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_integer_bi, hash_hmac('sha256', (string)0,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_boolean_bi, hash_hmac('sha256', (string)false,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_float_bi, hash_hmac('sha256', (string)0.0,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_date_bi, hash_hmac('sha256', (string)'2012-12-13 13:39:29',
-            env('APP_KEY')));
+            config('app.key')));
     }
 
     /**
@@ -441,11 +441,11 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals($model->encrypt_string_bi, '');
         $this->assertIsString($model->encrypt_string_bi);
         $this->assertEquals($model->encrypt_integer_bi, hash_hmac('sha256', (string)0,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_boolean_bi, hash_hmac('sha256', (string)false,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_float_bi, hash_hmac('sha256', (string)0.0,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_date_bi, null);
     }
 
@@ -485,7 +485,7 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals($model->encrypt_date, '2012-12-13 13:39:29');
         $this->assertEquals($model->hash_string,
             hash_hmac('sha256', 'Another unqiue string that has not been generated',
-                env('APP_KEY')));
+                config('app.key')));
 
         $this->assertIsString($model->encrypt_string);
         $this->assertIsInt($model->encrypt_integer);
@@ -496,15 +496,15 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertIsString($model->hash_string);
 
         $this->assertEquals($model->encrypt_string_bi, hash_hmac('sha256', (string)'newValue',
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_integer_bi, hash_hmac('sha256', (string)0,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_boolean_bi, hash_hmac('sha256', (string)false,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_float_bi, hash_hmac('sha256', (string)0.1,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_date_bi, hash_hmac('sha256', (string)'2012-12-13 13:39:29',
-            env('APP_KEY')));
+            config('app.key')));
     }
 
     /**
@@ -597,11 +597,11 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals($model->encrypt_string_bi, '');
         $this->assertIsString($model->encrypt_string_bi);
         $this->assertEquals($model->encrypt_integer_bi, hash_hmac('sha256', (string)0,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_boolean_bi, hash_hmac('sha256', (string)false,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_float_bi, hash_hmac('sha256', (string)0.0,
-            env('APP_KEY')));
+            config('app.key')));
         $this->assertEquals($model->encrypt_date_bi, null);
     }
 
@@ -939,7 +939,7 @@ class HasEncryptedAttributesTest extends TestCase
         $models = TestModel::whereBI(['encrypt_boolean' => true])->Get();
 
         $total = DB::table('test_tables')->where('encrypt_boolean_bi',
-            hash_hmac('sha256', (string)true, env('APP_KEY')))->count();
+            hash_hmac('sha256', (string)true, config('app.key')))->count();
 
         $this->assertEquals($total, count($models));
 
@@ -953,7 +953,7 @@ class HasEncryptedAttributesTest extends TestCase
         $models = TestModel::where(1,2)->orWhereBI(['encrypt_boolean' => true])->Get();
 
         $total = DB::table('test_tables')->where('encrypt_boolean_bi',
-            hash_hmac('sha256', (string)true, env('APP_KEY')))->count();
+            hash_hmac('sha256', (string)true, config('app.key')))->count();
 
         $this->assertEquals($total, count($models));
 
@@ -989,7 +989,6 @@ class HasEncryptedAttributesTest extends TestCase
         $models = TestModel::whereBI(['encrypt_float' => 10.0001])->Get();
 
         $this->assertEquals(1, count($models));
-
     }
 
     /**
@@ -1026,7 +1025,7 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals($array['encrypt_float'], 9999.999);
         $this->assertEquals($array['encrypt_date'], '2043-12-23 23:59:59');
         $this->assertEquals($array['hash_string'], hash_hmac('sha256', 'A unqiue string that has not been generated again',
-            env('APP_KEY')));
+            config('app.key')));
 
         $model->save();
 
@@ -1040,7 +1039,7 @@ class HasEncryptedAttributesTest extends TestCase
         $this->assertEquals($array['encrypt_float'], 9999.999);
         $this->assertEquals($array['encrypt_date'], '2043-12-23 23:59:59');
         $this->assertEquals($array['hash_string'], hash_hmac('sha256', 'A unqiue string that has not been generated again',
-            env('APP_KEY')));
+            config('app.key')));
 
         $models = TestModel::whereBI(['encrypt_float' => 9999.999])->Get();
         $this->assertEquals(1, count($models));
@@ -1081,20 +1080,6 @@ class HasEncryptedAttributesTest extends TestCase
         $models = TestModel::where(1,2)->orWhereBI(['encrypt_float' => 20.0001])->Get();
 
         $this->assertEquals(0, count($models));
-    }
-
-    public function envConfigTest()
-    {
-
-        echo "\n";
-        echo "\n";
-        echo config("app.key");
-        echo "\n";
-        echo env("APP_KEY");
-        echo "\n";
-        echo "\n";
-
-        $this->assertEquals(true, true);
     }
 
 }


### PR DESCRIPTION
- Using config() instead of env()
- Typo in `encriptedColumns` (breaking change!)
- Fixing tests